### PR TITLE
Check for user.emails

### DIFF
--- a/lib/meteor-analytics.js
+++ b/lib/meteor-analytics.js
@@ -2,7 +2,7 @@ trackLogins = function () {
   if (Meteor.user) {
     if (Meteor.user()) {
       var user = Meteor.user();
-      var userEmail = user.emails[0] ? user.emails[0].address : 'n/a';
+      var userEmail = user.emails && user.emails[0] ? user.emails[0].address : 'n/a';
       analytics.identify(user._id, {email: userEmail});
     }
 


### PR DESCRIPTION
`Meteor.user().emails` is not guaranteed to be defined.
