### PR TITLE
Add useraccounts:core and splendido:accounts-meld support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ analytics.track("Bought Ticket" {
 
 See the [analytics.js track documentation](https://segment.com/docs/libraries/analytics.js/#track) for a full description of `track()` and all the other functions available in this package.
 
+### Compatibility with useraccounts:core (using Iron Router `ensureSignedIn` plugin)
+
+If you use the `ensureSignedIn` plugin offered by [the usearccounts:core package](https://atmospherejs.com/useraccounts/core), you need to add the [revolutionlabs:user-login-state](https://atmospherejs.com/revolutionlabs/user-login-state) for compatibility. 
+
+### Compatibility with splendido:accounts-meld
+
+The [splendido:accounts-meld package](https://atmospherejs.com/splendido/accounts-meld) adds an extra field to the users collection, called `registered_emails`. Melded accounts will skip the `emails` field and fill this one instead.
+
+This package will try to read the first address in the `emails` field, then move on to `registered_emails` before identifying the current user.
+
 #### Track visitor scrolling
 
 Josh Owens' article, [Google Analytics events, goals, and Meteor.js](http://joshowens.me/google-analytics-events-goals-and-meteor-js/), goes over a great way to capture how far a visitor has scrolled down a page.

--- a/lib/meteor-analytics.js
+++ b/lib/meteor-analytics.js
@@ -3,16 +3,22 @@
 * Figure out the user's correct email address. This helps the differing keys
 * in the database when using oAuth login.
 */
-getUserEmail = function(userId){
-  var getUser = Meteor.users.findOne({_id: userId});
-  if ( getUser.emails ) {
-    if (getUser.emails[0]) {
-      return getUser.emails[0].address;
+
+getUserEmail = function(){
+  if ( Meteor.user().emails ) {
+    if (Meteor.user().emails[0]) {
+      return Meteor.user().emails[0].address;
     } else {
       return null;
     }
-  } else if ( getUser.services ) {
-    var services = getUser.services;
+  } else if ( Meteor.user().registered_emails ) {
+    if (Meteor.user().registered_emails[0]) {
+      return Meteor.user().registered_emails[0].address;
+    } else {
+      return null;
+    }
+  } else if ( Meteor.user().services ) {
+    var services = Meteor.user().services;
     if ( services.facebook ) {
       return services.facebook.email;
     } else if ( services.github ) {
@@ -28,23 +34,45 @@ getUserEmail = function(userId){
 trackLogins = function () {
   if (Meteor.user) {
     if (Meteor.user()) {
-      var user = Meteor.user();
-      var userEmail = getUserEmail(user._id)
-      analytics.identify(user._id, {email: userEmail});
+      trackSignIn();
     }
-
     if (!Meteor.user()) {
-      analytics.track("Signed out");
+      trackSignOut()
     }
   }
 };
 
+trackSignIn = function(){
+  var user = Meteor.user();
+  if (user) {
+    var userEmail = getUserEmail();
+    if(userEmail){
+      analytics.identify(user._id, {email: userEmail});
+    }else{
+      analytics.identify(user._id);
+    }
+
+    analytics.track("Signed in");
+  }
+}
+
+trackSignOut = function(){
+  analytics.track("Signed out");
+}
+
 if (Package['iron:router']) {
-  Package['iron:router'].Router.onAfterAction(function() {
+  Package['iron:router'].Router.onRun(function() {
     analytics.page(this.route.getName());
+    this.next();
   });
 }
 
 Meteor.startup(function () {
-  Tracker.autorun(trackLogins);
+  if(Package['revolutionlabs:user-login-state']){
+    UserLoginState.onLogin = trackSignIn;
+    UserLoginState.onLogout = trackSignOut;
+    UserLoginState.init();
+  }else{
+    Tracker.autorun(trackLogins);
+  }
 });

--- a/lib/server/publications.js
+++ b/lib/server/publications.js
@@ -1,0 +1,13 @@
+Meteor.publish(null, function() {
+  if(this.userId) {
+    return Meteor.users.find(
+      {_id: this.userId},
+      {fields: {  'services.facebook.email': 1,
+                  'services.google.email': 1,
+                  'services.github.email': 1,
+  	              'registered_emails': 1
+               }});
+  } else {
+    this.ready();
+  }
+});

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'okgrow:analytics',
-  version: '0.2.0',
+  version: '0.2.3',
   // Brief, one-line summary of the package.
   summary: 'Complete Google Analytics, Mixpanel, KISSmetrics (and more) integration for Meteor',
   // URL to the Git repository containing the source code for this package.
@@ -14,7 +14,9 @@ Package.onUse(function(api) {
   api.versionsFrom('1.0.3.1');
   api.use('browser-policy-content', 'server', {weak: true});
   api.use('iron:router@1.0.7', 'client', {weak: true});
+  api.use('revolutionlabs:user-login-state@1.0.1', {weak: true});
   api.addFiles('lib/browser-policy.js', 'server');
+  api.addFiles('lib/server/publications.js', 'server');
   api.addFiles([
     'lib/config.js',
     'vendor/analytics.min.js',


### PR DESCRIPTION
Fixes #18, might need a little polish before merging.

---

Track page changes onRun

Changed page tracking to onRun instead of onAfterAction.

From the iron:router docs:
"onRun: Called when the route is first run. It is not called again if the route reruns because of a computation invalidation. This makes it a good candidate for things like analytics where you want be sure the hook only runs once. Note that this hook won't run again if the route is reloaded via hot code push."

Update package.js
