### PR TITLE
Adds flow-router 2.0 support

### DIFF
--- a/lib/meteor-analytics.js
+++ b/lib/meteor-analytics.js
@@ -68,8 +68,9 @@ if (Package['iron:router']) {
   });
 }
 
-if (Package['meteorhacks:flow-router']) {
-  Package['meteorhacks:flow-router'].FlowRouter.triggers.enter([function(context){
+var flowRouterPackage = Package['meteorhacks:flow-router'] || Package['kadira:flow-router'];
+if (flowRouterPackage) {
+  flowRouterPackage.FlowRouter.triggers.enter([function(context){
     if (context.route && context.route.name) {
       analytics.page(context.route.name);
     } else {


### PR DESCRIPTION
Flow router 2.0 has been renamed from meteorhacks:flow-router to kadira:flow-router.
