### PR TITLE
Log route context as analytics parameters for Flow Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Complete analytics integration for Meteor
-Use one API to record and send your data from your Meteor app to your analytics platforms. 
+Use one API to record and send your data from your Meteor app to your analytics platforms.
 
 ### Installation
 
@@ -29,7 +29,7 @@ Add various platforms by adding each tool's configuration to your `settings.json
 It's important to note that service names and API key-namess provided above are specific to the platform. Make sure to use the correct service name and key shown for the plaform you're adding.
 
 > Q: What other analytics platforms are supported?  
-A: This package uses the [analytics.js](https://segment.com/docs/libraries/analytics.js/) open source project under the hood which does support many additional platforms. The challenge is using the correct API key-name and any other required options, but these setting can usually be found by looking at the individual integration repos. If you've used other services with the open-source codebase and can confirm the API options please submit a PR to update this example! 
+A: This package uses the [analytics.js](https://segment.com/docs/libraries/analytics.js/) open source project under the hood which does support many additional platforms. The challenge is using the correct API key-name and any other required options, but these setting can usually be found by looking at the individual integration repos. If you've used other services with the open-source codebase and can confirm the API options please submit a PR to update this example!
 
 #### Browser Policy
 
@@ -51,9 +51,9 @@ If your project doesn't use this package, then don't worry as it will not affect
 
 If you have the `accounts` package installed, this package will automatically track when a user logs in and logs out. Logging in will call identify on the user and associate their Meteor.userId to their previous anonymous activities.
 
-If you have the 'iron:router' package installed, this package will automatically track page-view events using your routes' names.
+If you have the 'iron:router' or 'kadira:flow-router' packages installed, this package will automatically track page-view events using your routes' names.
 
-If you do not use Iron Router, manually logging page views looks like this: `analytics.page('page name')`
+If you do not use Iron Router or Flow Router, manually logging page views looks like this: `analytics.page('page name')`
 
 ### Event tracking
 

--- a/examples/flow-router/.meteor/versions
+++ b/examples/flow-router/.meteor/versions
@@ -33,7 +33,7 @@ minimongo@1.0.8
 mobile-status-bar@1.0.3
 mongo@1.1.0
 observe-sequence@1.0.6
-okgrow:analytics@0.2.6
+okgrow:analytics@0.3.1
 ordered-dict@1.0.3
 random@1.0.3
 reactive-dict@1.1.0

--- a/examples/flow-router/flow-router.html
+++ b/examples/flow-router/flow-router.html
@@ -8,6 +8,10 @@
   <a href='/two'>Two</a>
   <a href='/three'>Three</a>
 
+  <a href='/first-level?level=1'>First Level</a>
+  <a href='/first-level/second-level?level=2&subdir=1'>Second Level</a>
+  <a href='/first-level/second-level/third-level?level=3&subdir=1'>Third Level</a>
+
 </body>
 
 <template name="mainLayout">
@@ -26,4 +30,16 @@
 
 <template name='three'>
   Hello Three
+</template>
+
+<template name='firstLevel'>
+  You are on the first level.
+</template>
+
+<template name='secondLevel'>
+  You are on the second level.
+</template>
+
+<template name='thirdLevel'>
+  You are on the third level.
 </template>

--- a/examples/flow-router/flow-router.js
+++ b/examples/flow-router/flow-router.js
@@ -1,15 +1,57 @@
-if (Meteor.isClient){
+if (Meteor.isClient) {
+
+  var firstLevelRoutes = FlowRouter.group({
+    name: 'First Level Group',
+    prefix: '/first-level'
+  });
+
+  var secondLevelRoutes = firstLevelRoutes.group({
+    name: 'Second Level Group',
+    prefix: '/second-level'
+  });
+
+  var thirdLevelRoutes = secondLevelRoutes.group({
+    name: 'Third Level Group',
+    prefix: '/third-level'
+  });
+
+  firstLevelRoutes.route('/', {
+    name: 'First Level Route',
+    action: function(params) {
+      FlowLayout.render("mainLayout", {main: "firstLevel"});
+    }
+  });
+
+  secondLevelRoutes.route('/', {
+    name: 'Second Level Route',
+    action: function(params) {
+      FlowLayout.render("mainLayout", {main: "secondLevel"});
+    }
+  });
+
+  thirdLevelRoutes.route('/', {
+    action: function(params) {
+      FlowLayout.render("mainLayout", {main: "thirdLevel"});
+    }
+  }); // without 'name', path is used for tracking
+
   FlowRouter.route('/one', {
     action: function(params) {
       FlowLayout.render("mainLayout", {main: "one"});
     },
-    name: "SomeName" // used for track
+    name: "One" // used for track
   });
+
   FlowRouter.route('/two', {
     action: function(params) {
       FlowLayout.render("mainLayout", {main: "two"});
     },
-    name: "AnotherName" // used for track
+    name: "Two" // used for track
   });
-  FlowRouter.route('/three') // without 'name', path is used for tracking
+
+  FlowRouter.route('/three', {
+    action: function(params) {
+      FlowLayout.render("mainLayout", {main: "three"});
+    }
+  }); // without 'name', path is used for tracking
 }

--- a/lib/meteor-analytics.js
+++ b/lib/meteor-analytics.js
@@ -70,11 +70,26 @@ if (Package['iron:router']) {
 
 if (Package['meteorhacks:flow-router']) {
   Package['meteorhacks:flow-router'].FlowRouter.triggers.enter([function(context){
+    var page = {};
+    page.path = context.context.pathname;
+    page.title = context.context.title;
+    page.url = window.location.origin + page.path;
+
     if (context.route && context.route.name) {
-      analytics.page(context.route.name);
+      page.name = context.route.name;
     } else {
-      analytics.page(context.path);
+      page.name = page.path;
     }
+    if (context.context.querystring) {
+      page.search = "?" + context.context.querystring;
+    } else {
+      page.search = "";
+    }
+    if (context.oldRoute && context.oldRoute.path) {
+      page.referrer = window.location.origin + context.oldRoute.path;
+    }
+
+    analytics.page(page.name, page);
   }]);
 }
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'okgrow:analytics',
-  version: '0.3.0',
+  version: '0.3.1',
   // Brief, one-line summary of the package.
   summary: 'Complete Google Analytics, Mixpanel, KISSmetrics (and more) integration for Meteor',
   // URL to the Git repository containing the source code for this package.


### PR DESCRIPTION
Fixes second issue in Issue #47 where some page parameters from the previous page were mixed up with page parameters of the current page, the page / route that is being entered and logged via triggers.enter in Flow Router.

Also, added Flow Router group routes with querystring parameters to the Flow Router example, in order to test whether or not group routes would fire the global trigger at each level or not.

And, added Flow Router support language to the README.
