### PR TITLE
Fix IronRouter support

### DIFF
--- a/lib/meteor-analytics.js
+++ b/lib/meteor-analytics.js
@@ -60,7 +60,7 @@ var identify = function () {
   });
 };
 
-var _IronRouter = (Package['iron:router'] && Package['iron:router'].IronRouter);
+var _IronRouter = (Package['iron:router'] && Package['iron:router'].Router);
 var _FlowRouter = (Package['kadira:flow-router'] && Package['kadira:flow-router'].FlowRouter) ||
                   (Package['meteorhacks:flow-router'] && Package['meteorhacks:flow-router'].FlowRouter) ||
                   (Package['kadira:flow-router-ssr'] && Package['kadira:flow-router-ssr'].FlowRouter) ||


### PR DESCRIPTION
Package['iron:router'].IronRouter returns undefined.
Package['iron:router'].Router works.

Not sure if/how this ever worked before. I don't think IronRouter has changed recently.
