### PR TITLE
Fix FlowRouter referrer url

### DIFF
--- a/client/meteor-analytics.js
+++ b/client/meteor-analytics.js
@@ -91,11 +91,15 @@ if (_IronRouter) {
 }
 
 if (_FlowRouter) {
+  var lastRoutePath;
   _FlowRouter.triggers.enter([function(context){
     var page = {};
-    page.path = context.context.pathname;
+    page.path = context.path;
     page.title = context.context.title;
     page.url = window.location.origin + page.path;
+
+    _FlowRouter.lastRoutePath = lastRoutePath;
+    lastRoutePath = page.path;
 
     if (context.route && context.route.name) {
       page.name = context.route.name;
@@ -107,9 +111,10 @@ if (_FlowRouter) {
     } else {
       page.search = "";
     }
-    if (context.oldRoute && context.oldRoute.path) {
-      // Todo: find a way to get the last path url without using a "_" key/function, since it could change in future releases of FLowRouter.
-      page.referrer = window.location.origin + _FlowRouter._oldExitPath;
+    if (_FlowRouter.lastRoutePath) {
+      page.referrer = window.location.origin + _FlowRouter.lastRoutePath;
+    } else {
+      page.referrer = document.referrer
     }
 
     trackPageWhenReady(page.name, page);

--- a/client/meteor-analytics.js
+++ b/client/meteor-analytics.js
@@ -108,7 +108,8 @@ if (_FlowRouter) {
       page.search = "";
     }
     if (context.oldRoute && context.oldRoute.path) {
-      page.referrer = window.location.origin + context.oldRoute.path;
+      // Todo: find a way to get the last path url without using a "_" key/function, since it could change in future releases of FLowRouter.
+      page.referrer = window.location.origin + _FlowRouter._oldExitPath;
     }
 
     trackPageWhenReady(page.name, page);


### PR DESCRIPTION
Current referrer routes for FlowRouter are broken. We record the Referrer URL with the value of `context.path` which returns FlowRouter's raw path (ex: /posts/:slug/:tag). We want the actual URL. This commit achieves that through FlowRouter._oldExitPath. It would be nice to find a way to do it with a documented/supported FlowRouter key instead of the "_" key.

The other solution would be to create a global Session variable set with a global `triggersExit` that would store the last route.

Thoughts?
