### PR TITLE
Remove dead example links from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,7 @@ Turn debug off with `analytics.debug(false)`
 ### Example Iron Router & Flow Router Apps
 
 This repo includes an `examples` directory containing 2 simple apps using iron router and flow router.
-These apps can be run from their directory with `meteor --settings settings.json`. You can also take a look with them on meteor.com at these links:
-
-Iron Router: http://okgrow-analytics-iron-router.meteor.com/
-
-Flow Router: http://okgrow-analytics-flow-router.meteor.com/
+These apps can be run from their directory with `meteor --settings settings.json`.
 
 ### License
 


### PR DESCRIPTION
Removed the dead links to the old example apps hosted on meteor's free hosting. 
We can add the links back once we decide where to host the example apps.
This PR will resolve issue #111 
