### PR TITLE
Iron router template route fix

### DIFF
--- a/examples/flow-router/.meteor/versions
+++ b/examples/flow-router/.meteor/versions
@@ -63,7 +63,7 @@ npm-mongo@1.4.39_1
 oauth@1.1.6
 oauth2@1.1.5
 observe-sequence@1.0.7
-okgrow:analytics@1.0.5
+okgrow:analytics@1.0.8
 ordered-dict@1.0.4
 promise@0.5.1
 random@1.0.5

--- a/examples/iron-router/.meteor/versions
+++ b/examples/iron-router/.meteor/versions
@@ -67,7 +67,7 @@ npm-mongo@1.4.39_1
 oauth@1.1.6
 oauth2@1.1.5
 observe-sequence@1.0.7
-okgrow:analytics@1.0.1
+okgrow:analytics@1.0.8
 ordered-dict@1.0.4
 promise@0.5.1
 random@1.0.5

--- a/examples/iron-router/iron-router.js
+++ b/examples/iron-router/iron-router.js
@@ -2,21 +2,29 @@ if (Meteor.isClient) {
   Router.route('/', function () {
     this.layout('mainLayout');
     this.render('one');
+  }, {
+    name: 'home'
   });
 
   Router.route('/one', function () {
     this.layout('mainLayout');
     this.render('one');
+  }, {
+    name: 'one'
   });
 
   Router.route('/two', function () {
     this.layout('mainLayout');
     this.render('two');
+  }, {
+    name: 'two'
   });
 
   Router.route('/three', function () {
     this.layout('mainLayout');
     this.render('three');
+  }, {
+    name: 'three'
   });
 
 


### PR DESCRIPTION
Bump okgrow:analytics package version for both examples.
Fixes bug `Uncaught Error: Handler with name 'route' already exists.` in iron-router example.
