### PR TITLE
bumped version to 2.0.0, added notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Complete analytics integration for Meteor
 Use one API thanks to Segment.io's [analytics.js](https://segment.com/docs/libraries/analytics.js/) to record and send your data from your Meteor app to your analytics platforms.
 
+### Pre Meteor 1.3.1
+For Meteor Apps older then v1.3.1, please use [v1.0.9](https://github.com/okgrow/analytics/releases/tag/v1.0.9) of this package. Going forward this package will officially only be supporting Meteor Apps >= v1.3.1
+
 ## Installation
 
 `> meteor add okgrow:analytics`
-
-### NOTE: 
-For Meteor Apps older then v1.3.1, please use [v1.0.9](https://github.com/okgrow/analytics/releases/tag/v1.0.9) of this package. Going forward this package will officially only be supporting Meteor Apps >= v1.3.1 
 
 ## Currently Supported Analytic Services
 * Amplitude
@@ -21,9 +21,9 @@ For Meteor Apps older then v1.3.1, please use [v1.0.9](https://github.com/okgrow
 * Quantcast
 * Segment.io
 
-## Development & Testing
+## Ad-blocker
 
-NOTE: Whilst running your Meteor App in "development mode" any ad-blocking web-browser extensions may block the entire "okgrow:analytics" package. This occurs due to the word "analytics" being used in the package name. Please note this only occurs when running Meteor in "development mode" due to the files not being bundled together. To work around this issue you can disable your ad-blocker whilst developing. To test that your application runs whilst an ad-blocker is enabled you can run your Meteor app with the following command:
+PLEASE NOTE: Whilst running your Meteor App in "development mode" any ad-blocking web-browser extensions may block the entire "okgrow:analytics" package. This occurs due to the word "analytics" being used in the package name. Please note this only occurs when running Meteor in "development mode" due to the files not being bundled together. To work around this issue you can disable your ad-blocker whilst developing. To test that your application runs whilst an ad-blocker is enabled you can run your Meteor app with the following command:
 
 `meteor run --production --settings settings.json`
 

--- a/examples/flow-router/.meteor/versions
+++ b/examples/flow-router/.meteor/versions
@@ -66,7 +66,7 @@ npm-mongo@1.4.45
 oauth@1.1.11
 oauth2@1.1.10
 observe-sequence@1.0.12
-okgrow:analytics@1.1.0
+okgrow:analytics@2.0.0
 ordered-dict@1.0.8
 promise@0.7.3
 random@1.0.10

--- a/examples/iron-router/.meteor/versions
+++ b/examples/iron-router/.meteor/versions
@@ -72,7 +72,7 @@ npm-mongo@1.4.45
 oauth@1.1.11
 oauth2@1.1.10
 observe-sequence@1.0.12
-okgrow:analytics@1.1.0
+okgrow:analytics@2.0.0
 ordered-dict@1.0.8
 promise@0.7.3
 random@1.0.10

--- a/package.js
+++ b/package.js
@@ -28,14 +28,10 @@ Package.onUse(function (api) {
   api.use("meteorhacks:flow-router@1.17.2", "client", { weak: true });
   api.use("kadira:flow-router@2.6.0", "client", { weak: true });
 
-  // For backward compatibility (< v1.3).
-  try {
-    api.mainModule("client-main.js", "client");
-    api.mainModule("server-main.js", "server");
-  } catch (e) {
-    // We supress and ignore error for backwards compatibility for apps < 1.3.1,
-    // reference to issue here https://github.com/meteor/meteor/issues/6713
-  }
-  // For backward compatibility.
+  // Client and server entry points
+  api.mainModule("client-main.js", "client");
+  api.mainModule("server-main.js", "server");
+
+  // For backward compatibility, pre import/export syntax
   api.export("analytics", ["client", "server"]);
 });

--- a/package.js
+++ b/package.js
@@ -1,12 +1,14 @@
 Package.describe({
   name: "okgrow:analytics",
-  version: "1.1.0",
+  version: "2.0.0",
   summary: "Complete Google Analytics, Mixpanel, KISSmetrics (and more) integration for Meteor",
   git: "https://github.com/okgrow/analytics",
   documentation: "README.md",
 });
 
 Package.onUse(function (api) {
+  // NOTE: symlink with example app causes error, upgrade to 1.3.2 or higher
+  // to run the examples. https://github.com/meteor/meteor/issues/6665
   api.versionsFrom("1.3.1");
 
   // "ecmascript" is mandatory dependency to compile our package's es6 code.
@@ -26,6 +28,7 @@ Package.onUse(function (api) {
   api.use("meteorhacks:flow-router@1.17.2", "client", { weak: true });
   api.use("kadira:flow-router@2.6.0", "client", { weak: true });
 
+  // For backward compatibility (< v1.3).
   try {
     api.mainModule("client-main.js", "client");
     api.mainModule("server-main.js", "server");


### PR DESCRIPTION
Bumped version to 2.0.0 , min version is currently set as 1.3.1.

Would be nice to bump this higher possibly ? As there are some sysmlink [bug](https://github.com/meteor/meteor/issues/6665) with the examples for 1.3.1 which is fixed in 1.3.2. Example apps are all 1.3.5+ atm.

There is already a NOTE: added in the readme. If you would like to make it more clear or change please add here. :)
