### PR TITLE
Removed link to non-existent `contributing.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ Released under the [MIT license](https://github.com/okgrow/analytics/blob/master
 
 ### Contributing
 
-Issues and Pull Requests are always welcome. Please read our [contribution guidelines](https://github.com/okgrow/guides/blob/master/contributing.md).
+Issues and Pull Requests are always welcome.


### PR DESCRIPTION
I guess it would be easier to write that guide.