### PR TITLE
v3.0.4

### DIFF
--- a/examples/flow-router/.meteor/versions
+++ b/examples/flow-router/.meteor/versions
@@ -72,7 +72,7 @@ npm-mongo@2.2.33
 oauth@1.1.13
 oauth2@1.1.11
 observe-sequence@1.0.16
-okgrow:analytics@3.0.3
+okgrow:analytics@3.0.4
 ordered-dict@1.0.9
 promise@0.9.0
 random@1.0.10

--- a/examples/iron-router/.meteor/versions
+++ b/examples/iron-router/.meteor/versions
@@ -78,7 +78,7 @@ npm-mongo@2.2.33
 oauth@1.1.13
 oauth2@1.1.11
 observe-sequence@1.0.16
-okgrow:analytics@3.0.3
+okgrow:analytics@3.0.4
 ordered-dict@1.0.9
 promise@0.9.0
 random@1.0.10

--- a/examples/react-router/.meteor/versions
+++ b/examples/react-router/.meteor/versions
@@ -60,7 +60,7 @@ npm-bcrypt@0.9.3
 npm-mongo@2.2.33
 observe-sequence@1.0.16
 okgrow:accounts-ui-react@0.8.0
-okgrow:analytics@3.0.3
+okgrow:analytics@3.0.4
 ordered-dict@1.0.9
 promise@0.9.0
 random@1.0.10

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'okgrow:analytics',
-  version: '3.0.3',
+  version: '3.0.4',
   summary: 'Extends @okgrow/auto-analytics adding automatic user identification for Meteor applications.',
   git: 'https://github.com/okgrow/analytics',
   documentation: 'README.md',
@@ -29,5 +29,5 @@ Package.onUse((api) => {
 });
 
 Npm.depends({
-  '@okgrow/auto-analytics': '1.0.3',
+  '@okgrow/auto-analytics': '1.0.4',
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Complete Google Analytics, Mixpanel, KISSmetrics (and more) integration for Meteor",
   "repository": {
     "type": "git",
@@ -29,6 +29,6 @@
     "eslint-plugin-meteor": "^4.0.1"
   },
   "dependencies": {
-    "@okgrow/auto-analytics": "1.0.3"
+    "@okgrow/auto-analytics": "1.0.4"
   }
 }


### PR DESCRIPTION
**Changes Made:**
- bumped  auto-analytics to latest release v1.0.4.
- `auto-analytics@1.0.4` changes include
  - removes fragment identifier from our `referrer`
  - updates the bundled `analytics.min.js` to latest.
- bump analytics to v3.0.4
- bump examples to v3.0.4